### PR TITLE
Fix CORS

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -27,6 +27,9 @@ curl 'https://api.oh.dddddddddzzzz.org/example.com/uid'
 
 export default {
   async fetch(request, env) {
+    if (request.method == 'OPTIONS') {
+      return new Response(null, {headers});
+    }
     if (request.method === 'GET') {
       if (url(request).pathname === '/') {
         return new Response(instruction, {headers})


### PR DESCRIPTION
Using JS to post a like does not work right now without no-cors. Unfortunately HTMX makes it difficult to set no-cors. It seems that CORS POST was intended to be allowed anyway.